### PR TITLE
Fix: Search now finds items in initially collapsed categories

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -347,7 +347,11 @@ function refreshInitialViewLists() {
 
                 const childListContainer = document.createElement('div');
                 childListContainer.className = 'child-list-container';
-                childListContainer.style.display = 'none';
+                childListContainer.style.display = 'none'; // Keep it initially collapsed
+
+                // Build the subtree immediately
+                buildSidebarNavigation(data[key], childListContainer, level + 1);
+
                 listItem.appendChild(childListContainer);
 
                 textElement.addEventListener('click', function(event) {
@@ -355,9 +359,6 @@ function refreshInitialViewLists() {
                     if (isCurrentlyCollapsed) {
                         childListContainer.style.display = 'block';
                         textElement.textContent = '▼ ' + key;
-                        if (childListContainer.innerHTML.trim() === '') {
-                            buildSidebarNavigation(data[key], childListContainer, level + 1);
-                        }
                     } else {
                         childListContainer.style.display = 'none';
                         textElement.textContent = '► ' + key;


### PR DESCRIPTION
The previous search implementation only considered items and categories that were already rendered in the DOM. Since sub-categories and their items were only rendered upon manual expansion of the parent category, searching for an item within a collapsed category would yield no results.

This commit modifies the `buildSidebarNavigation` function to recursively build the entire item tree in the DOM upon initial page load. Sub-categories are still visually collapsed by default using CSS, but their DOM elements (and the elements of their items) are present.

The `filterSidebar` and `recursiveFilter` functions can now operate on the complete item tree, correctly finding and displaying items regardless of their category's initial collapsed state.

I confirmed that:
- Items in deeply nested, initially collapsed categories are found.
- Clearing the search correctly resets the view.
- Partial matches and sequential searches behave as expected.